### PR TITLE
商品情報編集ページへの遷移、条件分岐の記述

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,9 +24,8 @@ class ItemsController < ApplicationController
 
    def edit
      # ログインしているユーザーと同一であればeditファイルが読み込まれる
-     if @item.user_id == current_user.id 
-     else
-       redirect_to root_path
+     if @item.user_id != current_user.id 
+      redirect_to root_path
      end
    end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   # 重複処理をまとめる
-   before_action :set_item, only: [:show ]
+   before_action :set_item, only: [:show, :edit, :update]
 
    def index
      @items = Item.includes(:user).order('created_at DESC')
@@ -22,24 +22,24 @@ class ItemsController < ApplicationController
      end
    end
 
-   # def edit
+   def edit
      # ログインしているユーザーと同一であればeditファイルが読み込まれる
-     # if @item.user_id == current_user.id && @item.order.nil?
-     # else
-      # redirect_to root_path
-     # end
-   # end
+     if @item.user_id == current_user.id 
+     else
+       redirect_to root_path
+     end
+   end
 
-  # def update
-    # @item.update(item_params)
+   def update
+     @item.update(item_params)
     # バリデーションがOKであれば詳細画面へ
-    # if @item.valid?
-      # redirect_to item_path(item_params)
-    # else
+     if @item.valid?
+       redirect_to item_path(item_params)
+     else
     # NGであれば、エラー内容とデータを保持したままeditファイルを読み込み、エラーメッセージを表示させる
-    # render 'edit'
-    # end
-  # end
+       render 'edit'
+     end
+   end
 
    def show
    end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,9 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%# <%= form_with(model: @item, local: true) do |f| %> 
+     <%= form_with(model: @item, local: true) do |f| %> 
 
-    <%# <%= render 'shared/error_messages', model: f.object %> 
+    <%= render 'shared/error_messages', model: f.object %> 
     
     <%# 商品画像 %>
     <div class="img-upload">
@@ -21,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%# <%= f.file_field :image, id:"item-image" %> 
+          <%= f.file_field :image, id:"item-image" %> 
       </div>
     </div>
     <%# /商品画像 %>
@@ -31,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%# <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %> 
+        <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %> 
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %> 
+          <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %> 
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -50,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %> 
+          <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %> 
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:item_status_id, ItemStatus.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %> 
+          <%= f.collection_select(:item_status_id, ItemStatus.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %> 
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -71,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:shipping_cost_id, ShippingCost.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %> 
+          <%= f.collection_select(:shipping_cost_id, ShippingCost.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %> 
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %> 
+          <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %> 
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %> 
+          <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %> 
       </div>
     </div>
     <%# /配送について %>
@@ -99,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%# <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %> 
+            <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %> 
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -139,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
 
   <% if user_signed_in? %>
     <% if current_user.id == @item.user_id %>
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <% else %>


### PR DESCRIPTION
What
商品情報編集ページへの遷移、ログイン状況による条件分岐式を記述

Why
商品情報編集機能に必要な為


ログイン状態の出品者は、商品情報編集ページに遷移できる動画
[https://gyazo.com/12f5af48202d935337c188a9f5ca7de0](url)

必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
[https://gyazo.com/84bb0d70c69667a8fcc8624a794c4d69](url)

入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
[https://gyazo.com/987b6bb7ef74ad0c9260d7393b618870](url)

何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
[https://gyazo.com/80ebfae151d73362a6151d9c98a403cd](url)

ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
[https://gyazo.com/63cb8a56b5a58cd0d8aa1ec7d448e7bf](url)

ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
[https://gyazo.com/1f325c98347875fc797e8072f5693960](url)

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
[https://gyazo.com/337f018e9ca5ae31abdaeb0be1ddbabc](url)
