### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   # 重複処理をまとめる
-   before_action :set_item, only: [:show, :edit, :update]
+   before_action :set_item, only: [:show, :edit, :update, :destroy]
 
    def index
      @items = Item.includes(:user).order('created_at DESC')
@@ -25,7 +25,7 @@ class ItemsController < ApplicationController
    def edit
      # ログインしているユーザーと同一であればeditファイルが読み込まれる
      if @item.user_id != current_user.id 
-      redirect_to root_path
+       redirect_to root_path
      end
    end
 
@@ -43,15 +43,15 @@ class ItemsController < ApplicationController
    def show
    end
 
-  # def destroy
+   def destroy
     # ログインしているユーザーと同一であればデータを削除する
-    # if @item.user_id == current_user.id
-      # @item.destroy
-      # redirect_to root_path
-    # else
-      # redirect_to root_path
-    # end
-  # end
+     if @item.user_id == current_user.id
+       @item.destroy
+       redirect_to root_path
+     else
+       redirect_to root_path
+     end
+   end
 
    private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
     <% if current_user.id == @item.user_id %>
       <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
     <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
What
商品削除機能を実装、ログインユーザー(出品者のみ)が出品した商品を削除できるように条件分岐。

Why
商品削除機能に必要な為

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
[https://gyazo.com/95c13550237c31f2c429b33a95c05f60](url)