### PR TITLE
商品購入機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,5 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 
 gem 'active_hash'
+
+gem 'payjp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -99,6 +101,9 @@ GEM
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -123,6 +128,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
@@ -138,6 +146,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.9)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
@@ -149,6 +158,8 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
+    payjp (0.0.10)
+      rest-client (~> 2.0)
     pg (1.5.3)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -198,6 +209,11 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rspec-core (3.12.1)
       rspec-support (~> 3.12.0)
@@ -268,6 +284,9 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -308,6 +327,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.5.3)
+  payjp
   pg
   pry-rails
   puma (~> 3.11)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,7 +24,7 @@ class ItemsController < ApplicationController
 
    def edit
      # ログインしているユーザーと同一であればeditファイルが読み込まれる
-     if @item.user_id != current_user.id 
+     if @item.user_id != current_user.id || @item.order.present?
        redirect_to root_path
      end
    end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -25,11 +25,11 @@ class OrdersController < ApplicationController
   end
 
   def pay_item
-    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+    Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
     Payjp::Charge.create(
-      amount: @item.price,        # 商品の値段
-      card: order_params[:token], # カードトークン
-      currency: 'jpy'             # 通貨の種類（日本円）
+      amount: @item.price,                 # 商品の値段
+      card: order_params[:token],          # カードトークン
+      currency: 'jpy'                      # 通貨の種類（日本円）
     )
   end
 
@@ -37,5 +37,5 @@ class OrdersController < ApplicationController
     # itemがあっての、order_form（入れ子構造）。他のコントローラーで生成されたitemを使うにはcreateアクションに定義する。
     @item = Item.find(params[:item_id])
     redirect_to root_path if current_user.id == @item.user_id || @item.order.present?
-   end
+  end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,19 +1,41 @@
 class OrdersController < ApplicationController
- # before_action :authenticate_user!
-  # before_action :non_purchased_item, only: [:index, :create]
+  before_action :authenticate_user!
+  before_action :non_purchased_item, only: [:index, :create]
   
-  # def index
-    # @order_form = OrderForm.new
-  # end
+  def index
+    @order_form = OrderForm.new
+  end
   
-  # def create
-    # @order_form = OrderForm.new(order_params)
-    # if @order_form.valid?
-      # pay_item
-      # @order_form.save
-      # redirect_to root_path
-    # else
-      # render :index
-    # end
-  # end
+  def create
+    @order_form = OrderForm.new(order_params)
+    if @order_form.valid?
+      pay_item
+      @order_form.save
+      redirect_to root_path
+    else
+      render :index
+    end
+  end
+  
+  private
+
+  def order_params
+    # この時点では、order_idが不要。またrequire外の情報は参照するため、mergeとする。
+    params.require(:order_form).permit(:postcode, :prefecture_id, :city, :block, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+  end
+
+  def pay_item
+    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+    Payjp::Charge.create(
+      amount: @item.price,        # 商品の値段
+      card: order_params[:token], # カードトークン
+      currency: 'jpy'             # 通貨の種類（日本円）
+    )
+  end
+
+  def non_purchased_item
+    # itemがあっての、order_form（入れ子構造）。他のコントローラーで生成されたitemを使うにはcreateアクションに定義する。
+    @item = Item.find(params[:item_id])
+    redirect_to root_path if current_user.id == @item.user_id || @item.order.present?
+   end
 end

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,32 @@
+const pay = () => {
+  const payjp = Payjp(process.env.PAYJP_PUBLIC_KEY);
+  const elements = payjp.elements();
+  const numberElement = elements.create('cardNumber');
+  const expiryElement = elements.create('cardExpiry');
+  const cvcElement = elements.create('cardCvc');
+  
+  numberElement.mount('#number-form');
+  expiryElement.mount('#expiry-form');
+  cvcElement.mount('#cvc-form');
+
+  const submit = document.getElementById("button");
+  
+  submit.addEventListener("click", (e) => {
+    e.preventDefault();
+    payjp.createToken(numberElement).then(function (response) {
+      if (response.error) {
+      } else {
+        const token = response.id;
+        const renderDom = document.getElementById("charge-form");
+        const tokenObj = `<input value=${token} name='token' type="hidden">`;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
+      }
+      numberElement.clear();
+      expiryElement.clear();
+      cvcElement.clear();
+      document.getElementById("charge-form").submit();
+    });
+  });
+};
+  
+window.addEventListener("load", pay);  

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,7 +9,7 @@ require("@rails/ujs").start()
 require("@rails/activestorage").start()
 require("channels")
 require("../item_price");
-
+require("../card");
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,8 +3,8 @@ class Item < ApplicationRecord
 
   # テーブルとのアソシエーション
    belongs_to :user
-  # has_one    :order
-  # has_many :comments
+   has_one    :order
+   has_many :comments
   
   # アクティブハッシュとのアソシエーション
    belongs_to :category

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,4 @@
  class Order < ApplicationRecord
-  # belongs_to :user
-  # belongs_to :item
+   belongs_to :user
+   belongs_to :item
  end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,5 @@
  class Order < ApplicationRecord
    belongs_to :user
    belongs_to :item
+   has_one :payment
  end

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -13,7 +13,7 @@ class OrderForm
     validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
     validates :city
     validates :block
-    validates :phone_number, format: { with: /\A[0-9]{11}\z/, message: 'is invalid' }
+    validates :phone_number, format: { with: /\A[0-9]{10,11}\z/, message: 'is invalid' }
     # トークンのバリデーション
     validates :token
   end

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -1,0 +1,26 @@
+class OrderForm
+  include ActiveModel::Model
+    # order_idは、保存されたタイミングで生成されるため、attr_accessorにおいて不要なカラムとなる（書くと蛇足なのでエラー）
+  attr_accessor :user_id, :item_id, :postcode, :prefecture_id, :city, :block, :building, :phone_number, :token
+  
+    # 4行目と同じくこのタイミングでは生成前なので「validates :order_id」は不要
+  with_options presence: true do
+    # orderモデルのバリデーション
+    validates :user_id
+    validates :item_id
+    # paymentモデルのバリデーション
+    validates :postcode, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Include hyphen(-)' }
+    validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
+    validates :city
+    validates :block
+    validates :phone_number, format: { with: /\A[0-9]{11}\z/, message: 'is invalid' }
+    # トークンのバリデーション
+    validates :token
+  end
+  
+  def save
+    order = Order.create(user_id: user_id, item_id: item_id)
+    # ストロングパラメーターでデータが運ばれ、それらが保存のタイミングで「order_id」が生成され、保存される。
+    Payment.create(order_id: order.id, postcode: postcode, prefecture_id: prefecture_id, city: city, block: block, building: building, phone_number: phone_number)
+  end
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,0 +1,3 @@
+class Payment < ApplicationRecord
+  belongs_to :order
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,15 +4,18 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :items
+  has_many :orders
+
   with_options presence: true do
           # 存在すること・確認用を含めて2回入力・6字以上はdeviseのデフォルト実装のため省略
           # 半角英数字（空文字NG）以外の場合には、メッセージを出す
     PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
     validates_format_of :password, with: PASSWORD_REGEX, message: 'Include both letters and numbers'
       
-    validates :nickname, uniqueness: true
+    validates :nickname
           # @含むこと・存在することはdeviseのデフォルト実装のため省略
-
+    validates :email,    uniqueness: true
           # 全角ひらがな、全角カタカナ、漢字
     validates :last_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/}
     validates :first_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/}

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,12 +133,10 @@
         <div class='item-img-content'>
         <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <%# <% if item.order != nil %> 
+          <% if item.order != nil %> 
           <div class='sold-out'>
-            <%# <span>Sold Out!!</span>  %>
+            <span>Sold Out!!</span> 
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
           <% end %>
         </div>
         <div class='item-info'>
@@ -155,6 +153,7 @@
         </div>
         <% end %>
       </li>
+    <% end %>
       
       <%# 商品がない場合は以下のダミー商品が表示される %>
     <% if @items.blank? then %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -32,7 +32,7 @@
       <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
     <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <%= link_to "購入画面に進む", item_orders_path(@item), class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
   <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,13 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image.variant(resize: '500x500'), class:"item-box-img" %>
-
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <%# <% if @item.order != nil %> 
+      <% if @item.order != nil %> 
       <div class="sold-out">
-        <%# <span>Sold Out!!</span> %>
+        <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -25,15 +23,13 @@
       </span>
     </div>
 
-  <% if user_signed_in? %>
+  <% if user_signed_in? && @item.order.blank?%>
     <% if current_user.id == @item.user_id %>
       <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
       <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
     <% else %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to "購入画面に進む", item_orders_path(@item), class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
   <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,8 @@
   <title>Furima</title>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
-  <script type="text/javascript" src="https://js.pay.jp/v1/"></script>
+  <%# ブラウザでアプリを開いた時にpayjp.jsを読み込む %>
+  <script type="text/javascript" src="https://js.pay.jp/v2/pay.js"></script>
   <%= stylesheet_link_tag 'application', media: 'all'%>
   <%= javascript_pack_tag 'application' %>
 </head>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,14 +7,14 @@
     </h1>
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <%= image_tag @item.image.variant(resize: '500x500'), class: 'buy-item-img' %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
-          <%= "商品名" %>
+          <%= @item.name %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= '999,999,999' %></p>
-          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+          <p class='item-price-text'>¥<%= @item.price %></p>
+          <p class='item-price-sub-text'><%= @item.shipping_cost.name %></p>
         </div>
       </div>
     </div>
@@ -26,12 +26,15 @@
         支払金額
       </h1>
       <p class='item-payment-price'>
-        ¥<%= "販売価格" %>
+        ¥<%= @item.price %>
       </p>
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= form_with(model: @order_form, url: item_orders_path(@item), id: 'charge-form', class: 'transaction-form-wrap',local: true) do |f| %>
+    
+    <%= render 'shared/error_messages', model: f.object %>
+
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -82,42 +85,42 @@
           <label class="form-text">郵便番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+        <%= f.text_field 'postcode', class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">都道府県</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">市区町村</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+        <%= f.text_field 'city', class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">番地</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+        <%= f.text_field 'block', class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">建物名</label>
           <span class="form-any">任意</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+        <%= f.text_field 'building', class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">電話番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+        <%= f.text_field 'phone_number', class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
       </div>
     </div>
     <%# /配送先の入力 %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -45,7 +45,8 @@
           <label class="form-text">カード情報</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"card-number", placeholder:"カード番号(半角英数字)", maxlength:"16" %>
+        <div id="number-form" class="input-default"></div>
+        
         <div class='available-card'>
           <%= image_tag 'card-visa.gif', class: 'card-logo'%>
           <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
@@ -59,10 +60,7 @@
           <span class="indispensable">必須</span>
         </div>
         <div class='input-expiration-date-wrap'>
-          <%= f.text_area :hoge, class:"input-expiration-date", id:"card-exp-month", placeholder:"例)3" %>
-          <p>月</p>
-          <%= f.text_area :hoge, class:"input-expiration-date", id:"card-exp-year", placeholder:"例)23" %>
-          <p>年</p>
+        <div id="expiry-form" class="input-default"></div>
         </div>
       </div>
       <div class="form-group">
@@ -70,7 +68,7 @@
           <label class="form-text">セキュリティコード</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"card-cvc", placeholder:"カード背面4桁もしくは3桁の番号", maxlength:"4" %>
+        <div id="cvc-form" class="input-default"></div>
       </div>
     </div>
     <%# /カード情報の入力 %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -17,7 +17,7 @@
     <ul class='lists-right'>
     <% if user_signed_in? %>
       
-      <li><%= link_to current_user.nickname, "/users/#{current_user.id}", class: "user-nickname" %></li>
+      <li><%= link_to current_user.nickname, "#", class: "user-nickname" %></li>
       <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: "logout" %> </li>
     <% else %> 
       <li><%= link_to 'ログイン', new_user_session_path, class: "login" %></li>

--- a/config/initializers/webpacker.rb
+++ b/config/initializers/webpacker.rb
@@ -1,0 +1,1 @@
+Webpacker::Compiler.env["PAYJP_PUBLIC_KEY"] = ENV["PAYJP_PUBLIC_KEY"]

--- a/db/migrate/20230711064445_create_payments.rb
+++ b/db/migrate/20230711064445_create_payments.rb
@@ -1,0 +1,14 @@
+class CreatePayments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :payments do |t|
+      t.references :order,         null: false, foreign_key: true
+      t.string     :postcode,      null: false
+      t.integer    :prefecture_id, null: false
+      t.string     :city,          null: false
+      t.string     :block,         null: false
+      t.string     :building
+      t.string     :phone_number,  null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_03_071001) do
+ActiveRecord::Schema.define(version: 2023_07_11_064445) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -57,6 +57,19 @@ ActiveRecord::Schema.define(version: 2023_07_03_071001) do
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
+  create_table "payments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "order_id", null: false
+    t.string "postcode", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "block", null: false
+    t.string "building"
+    t.string "phone_number", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["order_id"], name: "index_payments_on_order_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -79,4 +92,5 @@ ActiveRecord::Schema.define(version: 2023_07_03_071001) do
   add_foreign_key "items", "users"
   add_foreign_key "orders", "items"
   add_foreign_key "orders", "users"
+  add_foreign_key "payments", "orders"
 end

--- a/spec/factories/order_forms.rb
+++ b/spec/factories/order_forms.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :order_form do
+    user_id { Faker::Number.non_zero_digit }
+    item_id { Faker::Number.non_zero_digit }
+    postcode { Faker::Number.decimal_part(digits: 3) + '-' + Faker::Number.decimal_part(digits: 4) }
+    prefecture_id { Faker::Number.between(from: 1, to: 47) }
+    city { Faker::Address.city }
+    block { Faker::Address.street_address }
+    building { Faker::Address.street_address }
+    phone_number { Faker::Number.decimal_part(digits: 11) }
+    token { Faker::Internet.password(min_length: 20, max_length: 30) }
+  end
+end

--- a/spec/factories/order_forms.rb
+++ b/spec/factories/order_forms.rb
@@ -1,7 +1,5 @@
 FactoryBot.define do
   factory :order_form do
-    user_id { Faker::Number.non_zero_digit }
-    item_id { Faker::Number.non_zero_digit }
     postcode { Faker::Number.decimal_part(digits: 3) + '-' + Faker::Number.decimal_part(digits: 4) }
     prefecture_id { Faker::Number.between(from: 1, to: 47) }
     city { Faker::Address.city }

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :order do
-    
   end
 end

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :payment do
+    
+  end
+end

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
-  factory :payment do
-    
+  factory :payment do   
   end
 end

--- a/spec/models/order_form_spec.rb
+++ b/spec/models/order_form_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 RSpec.describe OrderForm, type: :model do
   before do
-    @order_form = FactoryBot.build(:order_form)
+    user = FactoryBot.create(:user)
+    item = FactoryBot.create(:item)
+    @order_form = FactoryBot.build(:order_form, user_id: user.id, item_id: item.id)
   end
 
   describe '配送先情報の保存' do

--- a/spec/models/order_form_spec.rb
+++ b/spec/models/order_form_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe OrderForm, type: :model do
+  before do
+    @order_form = FactoryBot.build(:order_form)
+  end
+
+  describe '配送先情報の保存' do
+    context '配送先情報の保存ができるとき' do
+      it 'すべての値が正しく入力されていれば保存できること' do
+        expect(@order_form).to be_valid
+      end
+      it 'user_idが空でなければ保存できる' do
+        @order_form.user_id = 1
+        expect(@order_form).to be_valid
+      end
+      it 'item_idが空でなければ保存できる' do
+        @order_form.item_id = 1
+        expect(@order_form).to be_valid
+      end
+      it '郵便番号が「3桁＋ハイフン＋4桁」の組み合わせであれば保存できる' do
+        @order_form.postcode = '123-4560'
+        expect(@order_form).to be_valid
+      end
+      it '都道府県が「---」以外かつ空でなければ保存できる' do
+        @order_form.prefecture_id = 1
+        expect(@order_form).to be_valid
+      end
+      it '市区町村が空でなければ保存できる' do
+        @order_form.city = '横浜市'
+        expect(@order_form).to be_valid
+      end
+      it '番地が空でなければ保存できる' do
+        @order_form.block = '旭区１２３'
+        expect(@order_form).to be_valid
+      end
+      it '建物名が空でも保存できる' do
+        @order_form.building = nil
+        expect(@order_form).to be_valid
+      end
+      it '電話番号が11番桁以内かつハイフンなしであれば保存できる' do
+        @order_form.phone_number = 12_345_678_910
+        expect(@order_form).to be_valid
+      end
+    end
+
+    context '配送先情報の保存ができないとき' do
+      it 'user_idが空だと保存できない' do
+        @order_form.user_id = nil
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include("User can't be blank")
+      end
+      it 'item_idが空だと保存できない' do
+        @order_form.item_id = nil
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include("Item can't be blank")
+      end
+      it '郵便番号が空だと保存できないこと' do
+        @order_form.postcode = nil
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include("Postcode can't be blank")
+      end
+      it '郵便番号にハイフンがないと保存できないこと' do
+        @order_form.postcode = 1_234_567
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include('Postcode is invalid. Include hyphen(-)')
+      end
+      it '都道府県が「---」だと保存できないこと' do
+        @order_form.prefecture_id = 0
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include("Prefecture can't be blank")
+      end
+      it '都道府県が空だと保存できないこと' do
+        @order_form.prefecture_id = nil
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include("Prefecture can't be blank")
+      end
+      it '市区町村が空だと保存できないこと' do
+        @order_form.city = nil
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include("City can't be blank")
+      end
+      it '番地が空だと保存できないこと' do
+        @order_form.block = nil
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include("Block can't be blank")
+      end
+      it '電話番号が空だと保存できないこと' do
+        @order_form.phone_number = nil
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include("Phone number can't be blank")
+      end
+      it '電話番号にハイフンがあると保存できないこと' do
+        @order_form.phone_number = '123 - 1234 - 1234'
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include('Phone number is invalid')
+      end
+      it '電話番号が12桁以上あると保存できないこと' do
+        @order_form.phone_number = 12_345_678_910_123_111
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include('Phone number is invalid')
+      end
+      it '電話番号が9桁以下であると保存できないこと' do
+        @order_form.phone_number = 123_456_789
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include('Phone number is invalid')
+      end
+      it 'トークンが空だと保存できないこと' do
+        @order_form.token = nil
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include("Token can't be blank")
+      end
+    end
+  end
+end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Payment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/payments_request_spec.rb
+++ b/spec/requests/payments_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Payments", type: :request do
+
+end


### PR DESCRIPTION
What
クレジット決済機能、商品購入機能、order単体テストコードの実装
Why
商品購入機能の実装に必要な機能の為


必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画
[https://gyazo.com/d8605d7403bbe386eb18099e7c9f0117](url)

 入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画
[https://gyazo.com/dab7dcb93dfa11408f659612aa35d98a](url)

 ログイン状態の場合でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
[https://gyazo.com/7cb8496edac0e2f5bfde7e0b87f1568b](url)

 ログイン状態の場合でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
[https://gyazo.com/574040d52e7cf177bb07dff0f9d3e623](url)

 ログアウト状態の場合は、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
[https://gyazo.com/9c3947903d75ca71420c6c65d2283dc0](url)

 売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品一覧機能実装時に未実装であった為実装）
 売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品詳細機能実装時に未実装であった為実装）
こちらはまとめて一つの動画にしました！
[https://gyazo.com/594ca3919d45a4f1d93f2a54a12e7850](url)

 ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画（商品詳細機能実装時に未実装であった為実装）
[https://gyazo.com/9ebdd16ede1a96418c30ded9fc351dbd](url)

 ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（商品情報編集機能実装時に未実装であった為実装）
[https://gyazo.com/342b626680c9c65569f73882d9d8ff23](url)

 テスト結果の画像
[https://gyazo.com/7520588bb8661ed563462b92adb0cc0e](url)
